### PR TITLE
Use React 18 root element API

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
+const rootElement = document.getElementById("root");
+const root = createRoot(rootElement!); // eslint-disable-line
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById("root"),
+  </React.StrictMode>
 );


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Update main.tsx to use createRoot instead.

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis